### PR TITLE
Fix `memoryview`/`bytes` mismatch in `get_run_logs` on PostgreSQL

### DIFF
--- a/django_scheduled_tasks/base.py
+++ b/django_scheduled_tasks/base.py
@@ -162,7 +162,7 @@ def get_run_logs(
     from .models import ScheduledTaskRunLog
 
     run_logs = ScheduledTaskRunLog.objects.filter(task_hash__in=task_hash_map.keys())
-    run_log_map = {task_hash_map[run.task_hash]: run for run in run_logs}
+    run_log_map = {task_hash_map[bytes(run.task_hash)]: run for run in run_logs}
     return {schedule: run_log_map.get(schedule) for schedule in task_schedules}
 
 


### PR DESCRIPTION
## Summary

- Wrap `run.task_hash` in `bytes()` in `get_run_logs` to handle PostgreSQL's `BinaryField` returning `memoryview` instead of `bytes`

Fixes #14 

## Details

Django's `BinaryField` returns `memoryview` on PostgreSQL but `bytes` on SQLite. The `task_hash_map` dict in `get_run_logs` is keyed by `bytes` (from `to_sha_bytes()`), so looking up a `memoryview` key raises `KeyError`. Wrapping in `bytes()` normalizes the type across all backends.

## Test plan

- [ ] Verify existing tests pass on SQLite (no behavioral change — `bytes(bytes_value)` is a no-op)
- [ ] Verify the fix resolves the `KeyError` on PostgreSQL

🤖 Generated with [Claude Code](https://claude.com/claude-code)